### PR TITLE
Make metric checks not compile when mismatching metric types given

### DIFF
--- a/src/main/scala/com/github/timgent/sparkdataquality/checks/metrics/DualMetricCheck.scala
+++ b/src/main/scala/com/github/timgent/sparkdataquality/checks/metrics/DualMetricCheck.scala
@@ -18,8 +18,8 @@ import scala.reflect.ClassTag
   * @tparam MV
   */
 final case class DualMetricCheck[MV <: MetricValue](
-    dsMetric: MetricDescriptor,
-    dsToCompareMetric: MetricDescriptor,
+    dsMetric: MetricDescriptor { type MetricType = MV },
+    dsToCompareMetric: MetricDescriptor { type MetricType = MV },
     checkDescription: String,
     metricComparator: MetricComparator[MV]
 ) extends MetricsBasedCheck

--- a/src/main/scala/com/github/timgent/sparkdataquality/checks/metrics/SingleMetricCheck.scala
+++ b/src/main/scala/com/github/timgent/sparkdataquality/checks/metrics/SingleMetricCheck.scala
@@ -17,7 +17,7 @@ import scala.reflect.ClassTag
   * @param check - the check to be done
   * @tparam MV - the type of the MetricValue that will be calculated in order to complete this check
   */
-case class SingleMetricCheck[MV <: MetricValue](metric: MetricDescriptor, checkDescription: String)(
+case class SingleMetricCheck[MV <: MetricValue](metric: MetricDescriptor { type MetricType = MV }, checkDescription: String)(
     check: MV#T => RawCheckResult
 ) extends MetricsBasedCheck
     with SingleDsCheck {
@@ -56,7 +56,7 @@ object SingleMetricCheck {
     * @return
     */
   def thresholdBasedCheck[MV <: MetricValue](
-      metricDescriptor: MetricDescriptor,
+      metricDescriptor: MetricDescriptor { type MetricType = MV },
       description: String,
       threshold: AbsoluteThreshold[MV#T]
   ): SingleMetricCheck[MV] = {

--- a/src/main/scala/com/github/timgent/sparkdataquality/metrics/MetricDescriptor.scala
+++ b/src/main/scala/com/github/timgent/sparkdataquality/metrics/MetricDescriptor.scala
@@ -14,6 +14,8 @@ import com.github.timgent.sparkdataquality.metrics.MetricValue.NumericMetricValu
 private[sparkdataquality] trait MetricDescriptor {
   type MC <: MetricCalculator
 
+  type MetricType = MC#MetricType
+
   /**
     * The metricCalculator which contains key logic for calculating a MetricValue for this MetricDescriptor
     * @return the MetricCalculator

--- a/src/test/scala/com/github/timgent/sparkdataquality/checks/metrics/DualMetricCheckTest.scala
+++ b/src/test/scala/com/github/timgent/sparkdataquality/checks/metrics/DualMetricCheckTest.scala
@@ -1,0 +1,36 @@
+package com.github.timgent.sparkdataquality.checks.metrics
+
+import com.github.timgent.sparkdataquality.metrics.MetricComparator // DO NOT DELETE - required for test
+import com.github.timgent.sparkdataquality.metrics.MetricDescriptor.SumValuesMetric // DO NOT DELETE - required for test
+import com.github.timgent.sparkdataquality.metrics.MetricValue.{DoubleMetric, LongMetric} // DO NOT DELETE - required for test
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class DualMetricCheckTest extends AnyWordSpec with Matchers {
+  "DualMetricCheck" should {
+    "not compile" when {
+      "the metric type doesn't match the comparator type" in {
+        """
+          |DualMetricCheck(
+          |          SumValuesMetric[DoubleMetric](""),
+          |          SumValuesMetric[DoubleMetric](""),
+          |          "change in unprojected patients",
+          |          MetricComparator[LongMetric](???, ???)
+          |        )
+          |""".stripMargin shouldNot compile
+      }
+    }
+    "compile" when {
+      "the metric type matches the comparator type" in {
+        """
+          |DualMetricCheck(
+          |          SumValuesMetric[LongMetric](""),
+          |          SumValuesMetric[LongMetric](""),
+          |          "change in unprojected patients",
+          |          MetricComparator[LongMetric](???, ???)
+          |        )
+          |""".stripMargin should compile
+      }
+    }
+  }
+}

--- a/src/test/scala/com/github/timgent/sparkdataquality/checks/metrics/MetricsBasedCheckTest.scala
+++ b/src/test/scala/com/github/timgent/sparkdataquality/checks/metrics/MetricsBasedCheckTest.scala
@@ -3,6 +3,7 @@ package com.github.timgent.sparkdataquality.checks.metrics
 import com.github.timgent.sparkdataquality.checks.CheckDescription.{DualMetricCheckDescription, SingleMetricCheckDescription}
 import com.github.timgent.sparkdataquality.checks.DatasourceDescription.DualDsDescription
 import com.github.timgent.sparkdataquality.checks.{CheckResult, CheckStatus, QcType, RawCheckResult}
+import com.github.timgent.sparkdataquality.metrics.MetricDescriptor.{SizeMetric, SumValuesMetric}
 import com.github.timgent.sparkdataquality.metrics.MetricValue.{DoubleMetric, LongMetric}
 import com.github.timgent.sparkdataquality.metrics.{MetricComparator, MetricDescriptor, MetricFilter, SimpleMetricDescriptor}
 import com.github.timgent.sparkdataquality.thresholds.AbsoluteThreshold
@@ -76,8 +77,7 @@ class MetricsBasedCheckTest extends AnyWordSpec with DatasetSuiteBase with Match
   }
 
   "SingleMetricCheck" should {
-    val metric = stub[MetricDescriptor]
-    (metric.toSimpleMetricDescriptor _).when().returns(mock[SimpleMetricDescriptor])
+    val metric = SizeMetric()
     val exampleCheck = SingleMetricCheck[LongMetric](metric, "exampleCheck") { metricValue =>
       val isWithinThreshold = AbsoluteThreshold(2L, 2L).isWithinThreshold(metricValue)
       if (isWithinThreshold)

--- a/src/test/scala/com/github/timgent/sparkdataquality/checks/metrics/SingleMetricCheckTest.scala
+++ b/src/test/scala/com/github/timgent/sparkdataquality/checks/metrics/SingleMetricCheckTest.scala
@@ -1,0 +1,30 @@
+package com.github.timgent.sparkdataquality.checks.metrics
+
+import com.github.timgent.sparkdataquality.checks.{CheckStatus, RawCheckResult} // DO NOT DELETE - required for tests
+import com.github.timgent.sparkdataquality.metrics.MetricDescriptor.SumValuesMetric // DO NOT DELETE - required for tests
+import com.github.timgent.sparkdataquality.metrics.MetricValue.{DoubleMetric, LongMetric} // DO NOT DELETE - required for tests
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class SingleMetricCheckTest extends AnyWordSpec with Matchers {
+  "SingleMetricCheck" should {
+    "not compile" when {
+      "the checks metric type doesn't match the metrics metric type" in {
+        """
+          |SingleMetricCheck[LongMetric](SumValuesMetric[DoubleMetric](""), "someCheck") { double: Long =>
+          |  RawCheckResult(CheckStatus.Success, "someResultDescription")
+          |}
+          |""".stripMargin shouldNot compile
+      }
+    }
+    "compile" when {
+      "the checks metric type matches the metrics metric type" in {
+        """
+          |SingleMetricCheck[DoubleMetric](SumValuesMetric[DoubleMetric](""), "someCheck") { double: Long =>
+          |  RawCheckResult(CheckStatus.Success, "someResultDescription")
+          |}
+          |""".stripMargin shouldNot compile
+      }
+    }
+  }
+}


### PR DESCRIPTION
Addresses https://github.com/timgent/spark-data-quality/issues/69